### PR TITLE
Fix the initial el-get fetch to work again

### DIFF
--- a/init.el
+++ b/init.el
@@ -14,11 +14,11 @@
 (add-to-list 'load-path "~/.emacs.d/el-get/el-get")
 
 (unless (require 'el-get nil t)
-  (url-retrieve-synchronously
-   "https://github.com/dimitri/el-get/raw/master/el-get-install.el"
-   (lambda (s)
-     (end-of-buffer)
-     (eval-print-last-sexp))))
+  (with-current-buffer
+      (url-retrieve-synchronously
+       "https://github.com/dimitri/el-get/raw/master/el-get-install.el")
+    (end-of-buffer)
+    (eval-print-last-sexp)))
 
 ;; now either el-get is `require'd already, or have been `load'ed by the
 ;; el-get installer.


### PR DESCRIPTION
url-retrieve-synchronously returns the fetched buffer, it doesn't take
a callback.
